### PR TITLE
fix(next-intl): move i18n config to new location to resolve deprecation warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+#pnpm 
+pnpm-lock.yaml

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -12,8 +12,8 @@ export default getRequestConfig(async ({ locale }) => {
     messages: (
       await (locale === "en"
         ? // When using Turbopack, this will enable HMR for `en`
-          import("./messages/en.json")
-        : import(`./messages/${locale}.json`))
+          import("../messages/en.json")
+        : import(`../messages/${locale}.json`))
     ).default,
   };
 });


### PR DESCRIPTION
### What was fixed
- Resolved the deprecation warning related to `next-intl` configuration.
- Moved the i18n config file from `./src/i18n.ts` to the recommended path `./i18n/request.ts`.

### Why
To follow the new standards in `next-intl` v3.22 and avoid future issues or breaking changes.